### PR TITLE
Make Basic Auth explicit and add support for User-Agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ pip install getdrip
 
 ```
 >>> from getdrip import GetDripAPI
->>> drip = GetDripAPI(token="<token>", account_id="<account_id>")
+>>> drip = GetDripAPI(token="<token>", account_id="<account_id>", application_name="<application_name>")
 ```
+
+The application name is optional, and is sent as the User-Agent in the request to Drip if provided.
 
 
 Method  | Description

--- a/getdrip/__init__.py
+++ b/getdrip/__init__.py
@@ -26,105 +26,111 @@ class GetDripAPI(object):
         if not 'account_id' in kwrds.keys():
             raise AccountIDNotFound('Please provide account id')
 
+        self.headers = {
+            'Content-Type': 'application/vnd.api+json',
+        }
+
+        if 'application_name' in kwrds.keys():
+            self.headers['User-Agent'] = kwrds['application_name']
+
         self.token = kwrds['token']
         self.account_id = kwrds['account_id']
         self.api_url = 'https://api.getdrip.com/v2'
-        self.headers = {'Content-Type': 'application/vnd.api+json'}
-        self.auth_tuple = (kwrds['token'], '')
+        self.auth = requests.auth.HTTPBasicAuth(self.token, '')
 
     def fetch_all_campaign(self):
         url = '%s/%s/campaigns/' % (self.api_url, self.account_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def fetch_campaign(self, campaign_id):
         url = '%s/%s/campaigns/%s' % (self.api_url, self.account_id, campaign_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def fetch_accounts(self):
         url =  '%s/accounts'%(self.api_url)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def create_or_update_subscriber(self, payload):
         url = '%s/%s/subscribers' % (self.api_url, self.account_id)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code, response.json()
 
     def create_or_update_subscriber_batch(self, payload):
         url = '%s/%s/subscribers/batches' % (self.api_url, self.account_id)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code, response.json()
 
     def fetch_subscriber(self, subscriber_id):
         url = '%s/%s/subscribers/%s' % (self.api_url, self.account_id, subscriber_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def subscribe_subscriber(self, campaign_id, payload):
         url = '%s/%s/campaigns/%s/subscribers' % (self.api_url, self.account_id, campaign_id)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code, response.json()
 
     def list_of_all_subscribers(self):
         url = '%s/%s/subscribers' % (self.api_url, self.account_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def delete_subscriber(self, subscriber_id):
         url = '%s/%s/subscribers/%s' % (self.api_url, self.account_id, subscriber_id)
-        response = requests.delete(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.delete(url, headers=self.headers, auth=self.auth)
         return response.status_code
 
     def activate_campaign(self, campaign_id):
         url = '%s/%s/campaigns/%s/activate' % (self.api_url, self.account_id, campaign_id)
-        response = requests.post(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, auth=self.auth)
         return response.status_code
 
     def pause_campaign(self, campaign_id):
         url = '%s/%s/campaigns/%s/pause' % (self.api_url, self.account_id, campaign_id)
-        response = requests.post(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, auth=self.auth)
         return response.status_code
 
     def fetch_everyone_sucbscribed_to_campaign(self, campaign_id):
         url = '%s/%s/campaigns/%s/subscribers' % (self.api_url, self.account_id, campaign_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def tag_a_subscriber(self, payload):
         url = '%s/%s/tags' % (self.api_url, self.account_id)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code, response.json()
 
     def untag_a_subscriber(self, email, tag):
         url = '%s/%s/subscribers/%s/tags/%s' % (self.api_url, self.account_id, email, tag)
-        response = requests.delete(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.delete(url, headers=self.headers, auth=self.auth)
         return response.status_code
 
     def fetch_a_form(self, form_id):
         url = '%s/%s/forms/%s' % (self.api_url, self.account_id, form_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def fetch_list_of_goals(self):
         url = '%s/%s/goals' % (self.api_url, self.account_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def fetch_goal(self, goal_id):
         url = '%s/%s/goals/%s' % (self.api_url, self.account_id, goal_id)
-        response = requests.get(url, headers=self.headers, auth=self.auth_tuple)
+        response = requests.get(url, headers=self.headers, auth=self.auth)
         return response.status_code, response.json()
 
     def record_event(self, payload):
         url = '%s/%s/events' % (self.api_url, self.account_id)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code
 
     def record_purchase(self, email, payload):
         url = '%s/%s/subscribers/%s/purchases' % (self.api_url, self.account_id,
                                                   email)
-        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth_tuple)
+        response = requests.post(url, headers=self.headers, data=json.dumps(payload), auth=self.auth)
         return response.status_code, response.json()
 


### PR DESCRIPTION
I encountered the same issues as was found in issue #3 and I've fixed them in this PR.

This library did not work for me at all due to the implicit authentication method for the requests library falling back to "Bearer" instead of "Basic." I'm not sure why it did that, but it's easy to make Basic Auth explicit, and I've done so in this PR.

Without this PR, when I use the library, the headers that are being sent to Drip are incorrect:

{'Content-Type': 'application/vnd.api+json', 'Authorization': 'Bearer <token>'}

This PR makes the library explicitly use Basic Authentication for the requests library.

Additionally, I've added optional support for the User-Agent header as issue #3 also mentions.